### PR TITLE
feat: Create initial frontend structure for feed display

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,104 @@
+body {
+    font-family: sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+header {
+    background: #333;
+    color: #fff;
+    padding: 1rem 0;
+    text-align: center;
+}
+
+header h1 {
+    margin: 0;
+}
+
+main {
+    padding: 1rem;
+    max-width: 800px;
+    margin: 20px auto;
+    background: #fff;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+#feed-container {
+    /* Styles for the feed container itself, if any */
+}
+
+.thread {
+    border: 1px solid #ddd;
+    background-color: #fff;
+    margin-bottom: 20px;
+    padding: 15px;
+    border-radius: 5px;
+}
+
+.thread-subject {
+    margin-top: 0;
+    color: #0056b3; /* Dark blue for subject */
+}
+
+.thread-participants {
+    font-size: 0.9em;
+    color: #555;
+    margin-bottom: 5px;
+}
+
+.thread-last-reply {
+    font-size: 0.8em;
+    color: #777;
+    margin-bottom: 10px;
+}
+
+.thread-emails {
+    margin-top: 10px;
+    padding-left: 15px;
+    border-left: 3px solid #eee;
+}
+
+.email-summary {
+    border: 1px solid #eee;
+    background-color: #f9f9f9;
+    padding: 10px;
+    margin-bottom: 10px;
+    border-radius: 3px;
+}
+
+.email-sender {
+    font-weight: bold;
+    margin-bottom: 3px;
+    color: #333;
+}
+
+.email-preview {
+    font-size: 0.95em;
+    color: #444;
+    margin-bottom: 3px;
+}
+
+.email-timestamp {
+    font-size: 0.8em;
+    color: #888;
+    text-align: right;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem 0;
+    margin-top: 20px;
+    font-size: 0.9em;
+    color: #777;
+}
+
+/* Loading and error messages */
+#feed-container p {
+    text-align: center;
+    font-style: italic;
+    color: #777;
+    padding: 20px;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Epistol - Your Email Feed</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <header>
+        <h1>Epistol</h1>
+    </header>
+    <main>
+        <div id="feed-container">
+            <!-- Email threads will be loaded here by JavaScript -->
+        </div>
+    </main>
+    <footer>
+        <p>&copy; 2023 Epistol</p>
+    </footer>
+    <script src="js/api.js"></script>
+    <script src="js/app.js"></script>
+</body>
+</html>

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,0 +1,22 @@
+/**
+ * Fetches the email feed data from the backend API.
+ * @returns {Promise<Array<Object>>} A promise that resolves to an array of thread objects.
+ *                                   Returns an empty array in case of an error.
+ */
+async function getFeed() {
+    try {
+        const response = await fetch('../api/get_feed.php');
+        if (!response.ok) {
+            console.error('Error fetching feed:', response.status, response.statusText);
+            // It might be better to throw an error here and let the caller handle it
+            // For now, returning an empty array to prevent breaking the app.
+            return [];
+        }
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        console.error('Network error or JSON parsing error:', error);
+        // Return empty array or re-throw, depending on desired error handling strategy
+        return [];
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,104 @@
+document.addEventListener('DOMContentLoaded', () => {
+    loadFeed();
+});
+
+/**
+ * Loads the feed data from the API and renders it on the page.
+ */
+async function loadFeed() {
+    const feedContainer = document.getElementById('feed-container');
+    if (!feedContainer) {
+        console.error('Feed container not found!');
+        return;
+    }
+
+    // Clear previous content (e.g., loading message)
+    feedContainer.innerHTML = '<p>Loading feed...</p>';
+
+    try {
+        const threads = await getFeed(); // Assumes getFeed is globally available from api.js
+
+        if (!threads || threads.length === 0) {
+            feedContainer.innerHTML = '<p>No threads to display.</p>';
+            return;
+        }
+
+        feedContainer.innerHTML = ''; // Clear "Loading feed..." message
+
+        threads.forEach(thread => {
+            const threadElement = renderThread(thread);
+            feedContainer.appendChild(threadElement);
+        });
+    } catch (error) {
+        console.error('Error loading feed:', error);
+        feedContainer.innerHTML = '<p>Error loading feed. Please try again later.</p>';
+    }
+}
+
+/**
+ * Renders a single thread object into an HTML element.
+ * @param {Object} threadData - The thread data object.
+ * Expected structure: { thread_id, subject, participants, last_reply_time, emails: [{ email_id, sender_name, body_preview, timestamp }] }
+ * @returns {HTMLElement} A div element representing the thread.
+ */
+function renderThread(threadData) {
+    const threadDiv = document.createElement('div');
+    threadDiv.className = 'thread';
+    threadDiv.dataset.threadId = threadData.thread_id;
+
+    const subjectH2 = document.createElement('h2');
+    subjectH2.className = 'thread-subject';
+    subjectH2.textContent = threadData.subject || 'No Subject';
+    threadDiv.appendChild(subjectH2);
+
+    if (threadData.participants && threadData.participants.length > 0) {
+        const participantsP = document.createElement('p');
+        participantsP.className = 'thread-participants';
+        participantsP.textContent = 'Participants: ' + threadData.participants.join(', ');
+        threadDiv.appendChild(participantsP);
+    }
+
+    if (threadData.last_reply_time) {
+        const lastReplyP = document.createElement('p');
+        lastReplyP.className = 'thread-last-reply';
+        // Basic date formatting, consider using a library for more complex needs
+        lastReplyP.textContent = 'Last reply: ' + new Date(threadData.last_reply_time).toLocaleString();
+        threadDiv.appendChild(lastReplyP);
+    }
+
+    const emailsDiv = document.createElement('div');
+    emailsDiv.className = 'thread-emails';
+
+    if (threadData.emails && threadData.emails.length > 0) {
+        threadData.emails.forEach(email => {
+            const emailDiv = document.createElement('div');
+            emailDiv.className = 'email-summary';
+            emailDiv.dataset.emailId = email.email_id;
+
+            const senderP = document.createElement('p');
+            senderP.className = 'email-sender';
+            senderP.textContent = email.sender_name || 'Unknown Sender';
+            emailDiv.appendChild(senderP);
+
+            const previewP = document.createElement('p');
+            previewP.className = 'email-preview';
+            previewP.textContent = email.body_preview || 'No preview available.';
+            emailDiv.appendChild(previewP);
+
+            if (email.timestamp) {
+                const timestampP = document.createElement('p');
+                timestampP.className = 'email-timestamp';
+                timestampP.textContent = new Date(email.timestamp).toLocaleString();
+                emailDiv.appendChild(timestampP);
+            }
+            emailsDiv.appendChild(emailDiv);
+        });
+    } else {
+        const noEmailsP = document.createElement('p');
+        noEmailsP.textContent = 'No emails in this thread yet.';
+        emailsDiv.appendChild(noEmailsP);
+    }
+    threadDiv.appendChild(emailsDiv);
+
+    return threadDiv;
+}


### PR DESCRIPTION
This commit introduces the foundational files for the Epistol frontend:

- public/index.php: Basic HTML layout with a container for the feed, and links to CSS and JavaScript files.
- public/js/api.js: Contains the getFeed() function to fetch thread data from the backend API (../api/get_feed.php).
- public/js/app.js: Implements loadFeed() to orchestrate fetching and rendering data, and renderThread() to generate HTML for each thread and its emails. Attaches an event listener to load the feed on DOMContentLoaded.
- public/css/style.css: Provides initial basic styling for readability of the feed, threads, and email summaries.

These files establish the core read-only loop for the frontend, allowing the display of email threads fetched from the backend, as outlined in Milestone 1 of the project TODO.