### PR TITLE
I've implemented post statuses and filtering for you.

### DIFF
--- a/api/set_post_status.php
+++ b/api/set_post_status.php
@@ -29,7 +29,7 @@ $post_id = $data['post_id'] ?? null;
 $user_id = $data['user_id'] ?? null;
 $status = $data['status'] ?? null;
 
-$allowed_statuses = ['read', 'follow-up', 'important-info'];
+$allowed_statuses = ['read', 'follow-up', 'important-info', 'unread'];
 
 if (empty($post_id) || !is_numeric($post_id)) {
     http_response_code(400);

--- a/api/set_post_status.php
+++ b/api/set_post_status.php
@@ -1,0 +1,102 @@
+<?php
+
+require_once '../src/helpers.php';
+require_once '../src/db.php';
+require_once '../config/config.php';
+
+header('Content-Type: application/json');
+
+// Allow only POST requests
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['error' => 'Only POST requests are allowed']);
+    exit;
+}
+
+// Get input data
+// Allow for testing override of php://input
+$raw_input = isset($GLOBALS['mock_php_input']) ? $GLOBALS['mock_php_input'] : file_get_contents('php://input');
+$data = json_decode($raw_input, true);
+
+if ($data === null && empty($GLOBALS['mock_php_input'])) { // Allow empty mock_php_input to simulate null json_decode for specific tests if needed
+    http_response_code(400); // Bad Request
+    echo json_encode(['error' => 'Invalid JSON input']);
+    exit;
+}
+
+// Validate input parameters
+$post_id = $data['post_id'] ?? null;
+$user_id = $data['user_id'] ?? null;
+$status = $data['status'] ?? null;
+
+$allowed_statuses = ['read', 'follow-up', 'important-info'];
+
+if (empty($post_id) || !is_numeric($post_id)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'post_id is required and must be a number.']);
+    exit;
+}
+
+if (empty($user_id) || !is_numeric($user_id)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'user_id is required and must be a number.']);
+    exit;
+}
+
+if (empty($status) || !in_array($status, $allowed_statuses)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'status is required and must be one of: ' . implode(', ', $allowed_statuses)]);
+    exit;
+}
+
+// Database connection
+$pdo = get_db_connection();
+
+try {
+    // Check if post and user exist (optional, but good practice)
+    // For brevity, we'll assume they exist based on foreign key constraints
+
+    // Check if a status already exists for this post_id and user_id
+    $stmt_check = $pdo->prepare("SELECT id FROM post_statuses WHERE post_id = :post_id AND user_id = :user_id");
+    $stmt_check->bindParam(':post_id', $post_id, PDO::PARAM_INT);
+    $stmt_check->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+    $stmt_check->execute();
+    $existing_status = $stmt_check->fetch(PDO::FETCH_ASSOC);
+
+    if ($existing_status) {
+        // Update existing status
+        $stmt_update = $pdo->prepare("UPDATE post_statuses SET status = :status, created_at = CURRENT_TIMESTAMP WHERE id = :id");
+        $stmt_update->bindParam(':status', $status, PDO::PARAM_STR);
+        $stmt_update->bindParam(':id', $existing_status['id'], PDO::PARAM_INT);
+        if ($stmt_update->execute()) {
+            echo json_encode(['success' => true, 'message' => 'Post status updated successfully.']);
+        } else {
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to update post status.']);
+        }
+    } else {
+        // Insert new status
+        $stmt_insert = $pdo->prepare("INSERT INTO post_statuses (post_id, user_id, status) VALUES (:post_id, :user_id, :status)");
+        $stmt_insert->bindParam(':post_id', $post_id, PDO::PARAM_INT);
+        $stmt_insert->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+        $stmt_insert->bindParam(':status', $status, PDO::PARAM_STR);
+        if ($stmt_insert->execute()) {
+            echo json_encode(['success' => true, 'message' => 'Post status created successfully.', 'id' => $pdo->lastInsertId()]);
+        } else {
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to create post status.']);
+        }
+    }
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    // Log error to a file or monitoring system for production
+    // error_log("Database error in set_post_status.php: " . $e->getMessage());
+    echo json_encode(['error' => 'Database error: ' . $e->getMessage()]);
+} catch (Exception $e) {
+    http_response_code(500);
+    // error_log("General error in set_post_status.php: " . $e->getMessage());
+    echo json_encode(['error' => 'An unexpected error occurred: ' . $e->getMessage()]);
+}
+
+?>

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -33,6 +33,15 @@ CREATE TABLE group_members (
     PRIMARY KEY (user_id, group_id) -- Composite primary key
 );
 
+-- Post statuses table
+CREATE TABLE post_statuses (
+    id SERIAL PRIMARY KEY,
+    post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Indexes for faster lookups
 CREATE INDEX idx_users_username ON users(username);
 CREATE INDEX idx_users_email ON users(email);
@@ -41,3 +50,5 @@ CREATE INDEX idx_posts_user_id ON posts(user_id);
 CREATE INDEX idx_posts_group_id ON posts(group_id);
 CREATE INDEX idx_group_members_user_id ON group_members(user_id);
 CREATE INDEX idx_group_members_group_id ON group_members(group_id);
+CREATE INDEX idx_post_statuses_post_id ON post_statuses(post_id);
+CREATE INDEX idx_post_statuses_user_id ON post_statuses(user_id);

--- a/public/index.php
+++ b/public/index.php
@@ -31,6 +31,16 @@
                     <!-- Group options will be populated here -->
                 </select>
             </div>
+            <div id="status-filter-section">
+                <h3>Filter Feed by Status</h3>
+                <select id="status-feed-filter">
+                    <option value="">All Statuses</option>
+                    <option value="read">Read</option>
+                    <option value="unread">Unread</option>
+                    <option value="follow-up">Follow-up</option>
+                    <option value="important-info">Important Info</option>
+                </select>
+            </div>
         </aside>
         <div id="feed-container">
             <!-- Email threads will be loaded here by JavaScript -->

--- a/tests/GetFeedApiTest.php
+++ b/tests/GetFeedApiTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// It's good practice to have a BaseTestCase that handles DB setup.
+// For now, repeating some logic.
+// require_once __DIR__ . '/BaseApiTestCase.php';
+
+class GetFeedApiTest extends TestCase
+{
+    private static $pdo;
+
+    public static function setUpBeforeClass(): void
+    {
+        // This setup assumes that config.php will be included by the API script
+        // and DB_PATH will be defined. Tests run on this DB.
+        // Ideally, use a separate test DB configuration.
+        require_once __DIR__ . '/../config/config.php'; // To define DB_PATH etc.
+        require_once __DIR__ . '/../src/db.php';      // For get_db_connection()
+        require_once __DIR__ . '/../db/inject_test_data.php'; // For inject_initial_data
+
+        // Ensure a clean state by deleting and recreating the DB
+        if (defined('DB_PATH')) {
+            if (file_exists(DB_PATH)) {
+                unlink(DB_PATH);
+            }
+            self::$pdo = get_db_connection(); // This will create schema and run inject_initial_data
+        } else {
+            throw new \Exception("DB_PATH is not defined. Ensure config.php is loaded.");
+        }
+    }
+
+    protected function setUp(): void
+    {
+        // Clear post_statuses before each test for this API
+        self::$pdo->exec("DELETE FROM post_statuses;");
+        // Data from inject_initial_data.php is assumed to be:
+        // Users: user1 (id=1), user2 (id=2)
+        // Emails: email1 (id=1, thread_id=1, from_person_id=1 (user1's person_id)), email2 (id=2, thread_id=1, from_person_id=2), email3 (id=3, thread_id=2, from_person_id=1)
+        // Groups: group1 (id=1)
+        // EmailGroups: email1 in group1, email2 in group1
+        // We need to map users to person_ids based on inject_test_data.php
+        // Let's assume person_id for user1 is 'person_user1_id' and for user2 is 'person_user2_id'
+        // And post_id in post_statuses corresponds to email_id from the feed.
+    }
+
+    private function captureOutputAndHeaders(callable $callback, &$http_response_code) {
+        ob_start();
+        $callback();
+        $output = ob_get_clean();
+        // Note: Can't directly get http_response_code set by script without more complex setup.
+        // We'll infer based on JSON error presence.
+        return $output;
+    }
+
+    private function makeApiCall(array $params)
+    {
+        $_GET = $params;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        // $_SERVER['QUERY_STRING'] = http_build_query($params);
+
+        return $this->captureOutputAndHeaders(function () {
+            require __DIR__ . '/../api/get_feed.php';
+        }, $http_response_code);
+    }
+
+    public function testMissingUserIdParameter()
+    {
+        $output = $this->makeApiCall([]); // No user_id
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('error', $response);
+        $this->assertStringContainsString('Invalid or missing user_id', $response['error']);
+    }
+
+    public function testPostStatusPresenceAndDefault()
+    {
+        // Assuming user1 (person_id from user1) has email1 (id=1) and email3 (id=3)
+        // User ID 1 for these tests will correspond to the user who owns person_user1_id
+        $output = $this->makeApiCall(['user_id' => 1]);
+        $response = json_decode($output, true);
+
+        $this->assertArrayHasKey('data', $response);
+        $this->assertArrayHasKey('threads', $response['data']);
+        $this->assertNotEmpty($response['data']['threads']);
+
+        $foundEmail1 = false;
+        $foundEmail3 = false;
+        foreach ($response['data']['threads'] as $thread) {
+            foreach ($thread['emails'] as $email) {
+                $this->assertArrayHasKey('status', $email);
+                $this->assertEquals('unread', $email['status'], "Email ID {$email['email_id']} should default to unread.");
+                if ($email['email_id'] == 1) $foundEmail1 = true;
+                if ($email['email_id'] == 3) $foundEmail3 = true;
+            }
+        }
+        $this->assertTrue($foundEmail1, "Email 1 not found in feed for user 1.");
+        $this->assertTrue($foundEmail3, "Email 3 not found in feed for user 1.");
+    }
+
+    public function testFilterByReadStatus()
+    {
+        // Set email1 to 'read' for user_id 1
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (1, 1, 'read')");
+        // email3 for user_id 1 remains unread
+
+        $output = $this->makeApiCall(['user_id' => 1, 'status' => 'read']);
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('data', $response);
+
+        $emailsInResponse = [];
+        if(isset($response['data']['threads'])) {
+            foreach ($response['data']['threads'] as $thread) {
+                foreach ($thread['emails'] as $email) {
+                    $emailsInResponse[$email['email_id']] = $email;
+                }
+            }
+        }
+
+        $this->assertArrayHasKey(1, $emailsInResponse, "Email 1 (marked read) should be in the filtered response.");
+        $this->assertEquals('read', $emailsInResponse[1]['status']);
+        $this->assertArrayNotHasKey(3, $emailsInResponse, "Email 3 (unread) should NOT be in the 'read' filtered response.");
+        // Also check that email 2 (belonging to user 2) is not there.
+        $this->assertArrayNotHasKey(2, $emailsInResponse, "Email 2 (other user) should not be in user 1's feed.");
+    }
+
+    public function testFilterByUnreadStatus()
+    {
+        // email1 for user_id 1 is 'read'
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (1, 1, 'read')");
+        // email3 for user_id 1 has no entry in post_statuses, so it's 'unread' by default.
+        // email_id 4 (for user 1) explicitly 'unread'
+        self::$pdo->exec("INSERT OR IGNORE INTO emails (id, thread_id, from_person_id, subject, body_text, body_html, timestamp, snippet) VALUES (4, 2, 'person_user1_id', 'Subj4', 'Body4', '<p>Body4</p>', '2023-01-04 10:00:00', 'Snip4')");
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (4, 1, 'unread')");
+
+
+        $output = $this->makeApiCall(['user_id' => 1, 'status' => 'unread']);
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('data', $response);
+
+        $emailsInResponse = [];
+        if(isset($response['data']['threads'])) {
+            foreach ($response['data']['threads'] as $thread) {
+                foreach ($thread['emails'] as $email) {
+                    $emailsInResponse[$email['email_id']] = $email;
+                }
+            }
+        }
+
+        $this->assertArrayNotHasKey(1, $emailsInResponse, "Email 1 (read) should not be in 'unread' filter.");
+        $this->assertArrayHasKey(3, $emailsInResponse, "Email 3 (no status entry) should be in 'unread' filter.");
+        $this->assertEquals('unread', $emailsInResponse[3]['status']);
+        $this->assertArrayHasKey(4, $emailsInResponse, "Email 4 (explicitly unread) should be in 'unread' filter.");
+        $this->assertEquals('unread', $emailsInResponse[4]['status']);
+    }
+
+    public function testFilterByFollowUpStatus()
+    {
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (1, 1, 'follow-up')");
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (3, 1, 'read')");
+
+        $output = $this->makeApiCall(['user_id' => 1, 'status' => 'follow-up']);
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('data', $response);
+
+        $emailsInResponse = [];
+        if(isset($response['data']['threads'])) {
+            foreach ($response['data']['threads'] as $thread) {
+                foreach ($thread['emails'] as $email) {
+                    $emailsInResponse[$email['email_id']] = $email;
+                }
+            }
+        }
+        $this->assertArrayHasKey(1, $emailsInResponse, "Email 1 (follow-up) should be in the filtered response.");
+        $this->assertEquals('follow-up', $emailsInResponse[1]['status']);
+        $this->assertArrayNotHasKey(3, $emailsInResponse, "Email 3 (read) should NOT be in the 'follow-up' filtered response.");
+    }
+
+    public function testCombinedGroupAndStatusFilter()
+    {
+        // Assuming from inject_test_data.php:
+        // Email 1 (id=1) is in group1 (group_id=1), by user1 (person_user1_id)
+        // Email 3 (id=3) is NOT in any group, by user1
+        // Email 5 (id=5, new) by user1, in group1
+        self::$pdo->exec("INSERT OR IGNORE INTO emails (id, thread_id, from_person_id, subject, body_text, body_html, timestamp, snippet, group_id) VALUES (5, 2, 'person_user1_id', 'Subj5', 'Body5', '<p>Body5</p>', '2023-01-05 10:00:00', 'Snip5', 1)");
+
+        // Statuses for user_id 1:
+        // Email 1: read
+        // Email 3: follow-up
+        // Email 5: read
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (1, 1, 'read')");
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (3, 1, 'follow-up')");
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (5, 1, 'read')");
+
+        // Filter by group_id=1 AND status='read' for user_id=1
+        $output = $this->makeApiCall(['user_id' => 1, 'group_id' => 1, 'status' => 'read']);
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('data', $response);
+
+        $emailsInResponse = [];
+        $emailCount = 0;
+        if(isset($response['data']['threads'])) {
+            foreach ($response['data']['threads'] as $thread) {
+                foreach ($thread['emails'] as $email) {
+                    $emailsInResponse[$email['email_id']] = $email;
+                    $emailCount++;
+                }
+            }
+        }
+
+        $this->assertArrayHasKey(1, $emailsInResponse, "Email 1 (group1, read) should be in response.");
+        $this->assertEquals('read', $emailsInResponse[1]['status']);
+        $this->assertArrayHasKey(5, $emailsInResponse, "Email 5 (group1, read) should be in response.");
+        $this->assertEquals('read', $emailsInResponse[5]['status']);
+
+        $this->assertArrayNotHasKey(3, $emailsInResponse, "Email 3 (no group, follow-up) should NOT be in response.");
+        $this->assertEquals(2, $emailCount, "Should only be 2 emails matching group1 and status read for user 1.");
+    }
+}
+?>

--- a/tests/GetThreadApiTest.php
+++ b/tests/GetThreadApiTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class GetThreadApiTest extends TestCase
+{
+    private static $pdo;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/../config/config.php';
+        require_once __DIR__ . '/../src/db.php';
+        require_once __DIR__ . '/../db/inject_test_data.php';
+
+        if (defined('DB_PATH')) {
+            if (file_exists(DB_PATH)) {
+                unlink(DB_PATH);
+            }
+            self::$pdo = get_db_connection(); // Creates schema & injects initial data
+        } else {
+            throw new \Exception("DB_PATH is not defined.");
+        }
+    }
+
+    protected function setUp(): void
+    {
+        self::$pdo->exec("DELETE FROM post_statuses;");
+        // Assumed data from inject_test_data.php:
+        // User 1 (id=1, person_id='person_user1_id'), User 2 (id=2, person_id='person_user2_id')
+        // Thread 1 (id=1) contains Email 1 (id=1, from person_user1_id) and Email 2 (id=2, from person_user2_id)
+        // Thread 2 (id=2) contains Email 3 (id=3, from person_user1_id)
+    }
+
+    private function makeApiCall(array $params)
+    {
+        $_GET = $params;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        ob_start();
+        require __DIR__ . '/../api/get_thread.php';
+        return ob_get_clean();
+    }
+
+    public function testMissingThreadIdParameter()
+    {
+        $output = $this->makeApiCall(['user_id' => 1]);
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals('Valid thread_id is required.', $response['error']);
+    }
+
+    public function testMissingUserIdParameter()
+    {
+        $output = $this->makeApiCall(['thread_id' => 'thread_1']); // Assuming thread_1 is a valid ID from test data
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals('Invalid or missing user_id. User ID must be a positive integer.', $response['error']);
+    }
+
+    public function testThreadNotFound()
+    {
+        $output = $this->makeApiCall(['thread_id' => 'non_existent_thread_id_12345', 'user_id' => 1]);
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals('Thread not found.', $response['error']);
+    }
+
+    public function testPostStatusPresenceAndDefaultInThread()
+    {
+        // Fetch Thread 1 for User 1. Email 1 and Email 2 are in this thread.
+        // Email 1 is by user 1 (person_user1_id), Email 2 by user 2 (person_user2_id)
+        // User 1 is viewing.
+        $output = $this->makeApiCall(['thread_id' => 'thread1_id', 'user_id' => 1]); // Assuming thread1_id exists
+        $response = json_decode($output, true);
+
+        $this->assertArrayHasKey('data', $response, "Response data missing: $output");
+        $this->assertEquals('thread1_id', $response['data']['id']);
+        $this->assertNotEmpty($response['data']['emails']);
+
+        foreach ($response['data']['emails'] as $email) {
+            $this->assertArrayHasKey('status', $email, "Email ID {$email['id']} missing status field.");
+            // All emails in the thread should show a status relevant to user_id 1.
+            // If no status is set for email_id X for user_id 1, it defaults to 'unread'.
+            $this->assertEquals('unread', $email['status'], "Email ID {$email['id']} should default to unread for user 1.");
+        }
+    }
+
+    public function testSpecificPostStatusInThreadForViewingUser()
+    {
+        // Set status for Email 1 (id=1) to 'read' for User 1 (id=1)
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (1, 1, 'read')");
+        // Set status for Email 2 (id=2) to 'follow-up' for User 1 (id=1)
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (2, 1, 'follow-up')");
+
+        // User 1 views Thread 1 (which contains Email 1 and Email 2)
+        $output = $this->makeApiCall(['thread_id' => 'thread1_id', 'user_id' => 1]);
+        $response = json_decode($output, true);
+
+        $this->assertArrayHasKey('data', $response);
+        $this->assertNotEmpty($response['data']['emails']);
+
+        $statusesFound = [];
+        foreach ($response['data']['emails'] as $email) {
+            $statusesFound[$email['id']] = $email['status'];
+        }
+
+        $this->assertEquals('read', $statusesFound[1], "Email 1 should be 'read' for user 1.");
+        $this->assertEquals('follow-up', $statusesFound[2], "Email 2 should be 'follow-up' for user 1.");
+    }
+
+    public function testStatusInThreadForDifferentUser()
+    {
+        // User 1 marks Email 1 (id=1) as 'important-info'
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (1, 1, 'important-info')");
+        // User 2 marks Email 1 (id=1) as 'read'
+        self::$pdo->exec("INSERT INTO post_statuses (post_id, user_id, status) VALUES (1, 2, 'read')");
+
+        // User 2 views Thread 1 (which contains Email 1)
+        $output = $this->makeApiCall(['thread_id' => 'thread1_id', 'user_id' => 2]);
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('data', $response);
+        $email1StatusForUser2 = null;
+        foreach ($response['data']['emails'] as $email) {
+            if ($email['id'] == 1) {
+                $email1StatusForUser2 = $email['status'];
+                break;
+            }
+        }
+        $this->assertEquals('read', $email1StatusForUser2, "Email 1 should be 'read' for user 2.");
+
+        // User 1 views Thread 1
+        $outputUser1 = $this->makeApiCall(['thread_id' => 'thread1_id', 'user_id' => 1]);
+        $responseUser1 = json_decode($outputUser1, true);
+        $this->assertArrayHasKey('data', $responseUser1);
+        $email1StatusForUser1 = null;
+        foreach ($responseUser1['data']['emails'] as $email) {
+            if ($email['id'] == 1) {
+                $email1StatusForUser1 = $email['status'];
+                break;
+            }
+        }
+        $this->assertEquals('important-info', $email1StatusForUser1, "Email 1 should be 'important-info' for user 1.");
+    }
+}
+?>

--- a/tests/SetPostStatusApiTest.php
+++ b/tests/SetPostStatusApiTest.php
@@ -1,0 +1,223 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SetPostStatusApiTest extends TestCase
+{
+    private static $db_path;
+    private static $backup_db_path;
+    private static $original_db_content;
+
+    public static function setUpBeforeClass(): void
+    {
+        // Define a test-specific database path
+        self::$db_path = __DIR__ . '/../storage/test_api_database.sqlite';
+        self::$backup_db_path = __DIR__ . '/../storage/test_api_database.sqlite.backup';
+
+        // It's crucial that config.php uses an environment variable for DB_PATH
+        // or that we can override it here. For now, we'll assume config.php
+        // might pick up an env var, or we run tests in an environment where DB_PATH
+        // can point to our test DB.
+        // If not, tests will run on the dev DB, which is not ideal.
+        // Let's try to define DB_PATH here IF NOT ALREADY DEFINED.
+        if (!defined('DB_PATH_OVERRIDE_FOR_TESTS')) {
+            define('DB_PATH_OVERRIDE_FOR_TESTS', self::$db_path);
+        }
+
+        // Backup existing test DB if it exists, then delete the main test DB file
+        // to ensure a clean state for schema creation by get_db_connection().
+        if (file_exists(self::$db_path)) {
+            copy(self::$db_path, self::$backup_db_path);
+            unlink(self::$db_path);
+        }
+
+        // Ensure config.php is loaded for get_db_connection()
+        // This will define the original DB_PATH if not overridden by an env var strategy.
+        require_once __DIR__ . '/../config/config.php';
+        // Now, if DB_PATH_OVERRIDE_FOR_TESTS was used by config.php, we are good.
+        // Otherwise, we need a different strategy.
+
+        // For this test setup, we will temporarily replace the DB_PATH constant.
+        // This is hacky and relies on runkit or similar, or redefining constants if possible.
+        // A cleaner way is for config.php to respect an ENV variable for DB_PATH.
+        // Since we can't modify config.php, this test will be "less isolated" if it uses the main DB.
+
+        // To ensure get_db_connection creates a fresh DB with schema:
+        if (file_exists(DB_PATH) && DB_PATH === self::$db_path) { // Only delete if DB_PATH is our test DB
+            unlink(DB_PATH);
+        } elseif (DB_PATH !== self::$db_path) {
+            // Fallback: If DB_PATH is not our test DB path, we can't isolate.
+            // We'll save the original DB content and restore it.
+            // This is also risky if multiple tests run concurrently or if a test fails mid-way.
+            self::$original_db_content = file_get_contents(DB_PATH);
+        }
+         // Initialize PDO and schema (get_db_connection will handle this)
+        get_db_connection();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (defined('DB_PATH_OVERRIDE_FOR_TESTS') && file_exists(self::$db_path)) {
+            if (file_exists(self::$backup_db_path)) {
+                rename(self::$backup_db_path, self::$db_path); // Restore backup
+            } else {
+                unlink(self::$db_path); // Clean up test DB
+            }
+        } elseif (isset(self::$original_db_content) && defined('DB_PATH')) {
+            file_put_contents(DB_PATH, self::$original_db_content); // Restore original DB
+        }
+    }
+
+    protected function setUp(): void
+    {
+        // If not using DB_PATH_OVERRIDE_FOR_TESTS, we might need to re-apply schema for each test
+        // or ensure data from one test doesn't affect another.
+        // For now, assuming setUpBeforeClass handles the main DB setup.
+        // Individual test methods will add specific data as needed.
+        $pdo = get_db_connection(); // Ensure connection for each test
+        // Clear post_statuses table for isolation between tests for this specific API
+        $pdo->exec("DELETE FROM post_statuses;");
+        // Add a dummy post and user for FK constraints if they don't exist from inject_test_data
+        // inject_test_data.php should provide users user1 (id 1), user2 (id 2)
+        // and posts post1_user1 (id 1), post2_user1 (id 2), post1_user2 (id 3)
+        // For safety, let's ensure necessary records exist or add them.
+        try {
+            $pdo->exec("INSERT OR IGNORE INTO users (id, username, email, password_hash) VALUES (1, 'testuser1', 'testuser1@example.com', 'hash1')");
+            $pdo->exec("INSERT OR IGNORE INTO users (id, username, email, password_hash) VALUES (99, 'testuser99', 'testuser99@example.com', 'hash99')");
+            $pdo->exec("INSERT OR IGNORE INTO posts (id, user_id, content) VALUES (1, 1, 'Test post 1 by user 1')");
+            $pdo->exec("INSERT OR IGNORE INTO posts (id, user_id, content) VALUES (99, 99, 'Test post 99 by user 99')");
+        } catch (PDOException $e) {
+            // Ignore if already exists, or handle error
+        }
+    }
+
+    private function captureOutput(callable $callback)
+    {
+        ob_start();
+        $callback();
+        return ob_get_clean();
+    }
+
+    public function testSetNewStatusSuccess()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $inputData = ['post_id' => 1, 'user_id' => 1, 'status' => 'read'];
+        // Simulate file_get_contents('php://input')
+        $GLOBALS['mock_php_input'] = json_encode($inputData);
+
+        $output = $this->captureOutput(function () {
+            require __DIR__ . '/../api/set_post_status.php';
+        });
+        unset($GLOBALS['mock_php_input']); // Clean up
+
+        $this->assertJson($output);
+        $response = json_decode($output, true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals('Post status created successfully.', $response['message']);
+        $this->assertArrayHasKey('id', $response);
+
+        // Check database
+        $pdo = get_db_connection();
+        $stmt = $pdo->prepare("SELECT status FROM post_statuses WHERE post_id = :post_id AND user_id = :user_id");
+        $stmt->execute(['post_id' => 1, 'user_id' => 1]);
+        $this->assertEquals('read', $stmt->fetchColumn());
+    }
+
+    public function testUpdateExistingStatusSuccess()
+    {
+        // First, set an initial status
+        $pdo = get_db_connection();
+        $stmt_initial = $pdo->prepare("INSERT INTO post_statuses (post_id, user_id, status) VALUES (:post_id, :user_id, :status)");
+        $stmt_initial->execute(['post_id' => 1, 'user_id' => 1, 'status' => 'read']);
+        $initial_id = $pdo->lastInsertId();
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $inputData = ['post_id' => 1, 'user_id' => 1, 'status' => 'important-info'];
+        $GLOBALS['mock_php_input'] = json_encode($inputData);
+
+        $output = $this->captureOutput(function () {
+            require __DIR__ . '/../api/set_post_status.php';
+        });
+        unset($GLOBALS['mock_php_input']);
+
+        $this->assertJson($output);
+        $response = json_decode($output, true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals('Post status updated successfully.', $response['message']);
+
+        // Check database
+        $stmt = $pdo->prepare("SELECT status FROM post_statuses WHERE id = :id");
+        $stmt->execute(['id' => $initial_id]);
+        $this->assertEquals('important-info', $stmt->fetchColumn());
+    }
+
+    public function testMissingParameters()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $inputs = [
+            ['user_id' => 1, 'status' => 'read'], // Missing post_id
+            ['post_id' => 1, 'status' => 'read'], // Missing user_id
+            ['post_id' => 1, 'user_id' => 1],    // Missing status
+        ];
+
+        foreach ($inputs as $idx => $inputData) {
+            $GLOBALS['mock_php_input'] = json_encode($inputData);
+            $output = $this->captureOutput(function () {
+                require __DIR__ . '/../api/set_post_status.php';
+            });
+            unset($GLOBALS['mock_php_input']);
+
+            $response = json_decode($output, true);
+            $this->assertArrayHasKey('error', $response, "Failed on input index $idx: " . $output);
+            // Check for 400 Bad Request, though http_response_code is harder to test directly this way
+        }
+    }
+
+    public function testInvalidStatusValue()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $inputData = ['post_id' => 1, 'user_id' => 1, 'status' => 'invalid_status_value'];
+        $GLOBALS['mock_php_input'] = json_encode($inputData);
+
+        $output = $this->captureOutput(function () {
+            require __DIR__ . '/../api/set_post_status.php';
+        });
+        unset($GLOBALS['mock_php_input']);
+
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('error', $response);
+        $this->assertStringContainsString('status is required and must be one of', $response['error']);
+    }
+
+    public function testNonPostRequest()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $output = $this->captureOutput(function () {
+            require __DIR__ . '/../api/set_post_status.php';
+        });
+
+        $response = json_decode($output, true);
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals('Only POST requests are allowed', $response['error']);
+        // PHPUnit can't easily check http_response_code set by the script directly without a proper web server context
+        // or more advanced testing tools like Guzzle for actual HTTP requests.
+    }
+
+    // Helper to override file_get_contents('php://input') used in set_post_status.php
+    // This needs to be in the global namespace or accessible.
+    // This is tricky. A better way is to refactor set_post_status.php to be more testable,
+    // e.g., by having it accept input as a parameter.
+    // For now, $GLOBALS['mock_php_input'] is a simple workaround.
+}
+
+// Need to ensure set_post_status.php can use our mock if $GLOBALS['mock_php_input'] is set.
+// This usually means modifying the source file, which we are trying to avoid for the API script.
+// A common pattern for set_post_status.php would be:
+// $raw_input = file_get_contents('php://input');
+// $data = json_decode($raw_input, true);
+// We can't easily mock file_get_contents('php://input') without extensions like uopz or by refactoring the script.
+// The $GLOBALS approach is a hack.
+// Let's assume for now that set_post_status.php is modified to check this global for testing:
+// $raw_input = isset($GLOBALS['mock_php_input']) ? $GLOBALS['mock_php_input'] : file_get_contents('php://input');
+
+?>


### PR DESCRIPTION
This update introduces the ability for you to manually set a status for posts/emails (e.g., read, follow-up, important-info) and filter your feed based on these statuses.

Here are the key changes:

- Database:
    - I added a new `post_statuses` table to store the status of each post for each user.
- API:
    - I created a new endpoint `api/set_post_status.php` to allow setting or updating the status of a post.
    - I modified `api/get_feed.php` and `api/get_thread.php` to:
        - Require a `user_id` parameter.
        - Include the `post_status` for each email, defaulting to 'unread'. - Support filtering the feed by status (e.g., `?status=read`).
- Frontend:
    - I updated `public/js/api.js` and `public/js/app.js`.
    - Email views now display the current status and a dropdown to change it.
    - A new filter dropdown has been added to the sidebar in `public/index.php` to filter the feed by status.
    - Status changes are reflected immediately in the UI, and the feed is reloaded.
    - Both group and status filters can be applied simultaneously.
- Testing:
    - I added PHPUnit tests for the new and modified backend API endpoints (`SetPostStatusApiTest`, `GetFeedApiTest`, `GetThreadApiTest`).
    - These tests cover status setting, retrieval, default values, and filtering logic.

I'm aware of a couple of limitations:
- Pagination in the feed is global and does not currently consider active group or status filters for calculating total pages.
- Frontend JavaScript does not have automated unit tests due to the lack of an existing testing framework.