### PR TITLE
feat: Improve feed readability and fix mail status handling

### DIFF
--- a/api/v1/set_post_status.php
+++ b/api/v1/set_post_status.php
@@ -69,13 +69,13 @@ if ($data === null && json_last_error() !== JSON_ERROR_NONE && empty($GLOBALS['m
 }
 
 // Validate input parameters
-$post_id = $data['post_id'] ?? null;
+$email_id = $data['email_id'] ?? null;
 $user_id = $data['user_id'] ?? null; // Assuming user_id is integer as per validation
 $status = $data['status'] ?? null;
 
 $allowed_statuses = ['read', 'follow-up', 'important-info', 'unread'];
 
-if (empty($post_id) || !is_numeric($post_id)) {
+if (empty($email_id) || !is_numeric($email_id)) {
     send_json_error('email_id is required and must be a number.', 400);
 }
 
@@ -94,7 +94,7 @@ try {
     // Check if a status already exists for this email_id and user_id
     // Assuming email_statuses table has 'id' as PK, 'email_id', 'user_id', 'status', 'created_at', 'updated_at'
     $stmt_check = $pdo->prepare("SELECT id FROM email_statuses WHERE email_id = :email_id AND user_id = :user_id");
-    $stmt_check->bindParam(':email_id', $post_id, PDO::PARAM_INT);
+    $stmt_check->bindParam(':email_id', $email_id, PDO::PARAM_INT);
     $stmt_check->bindParam(':user_id', $user_id, PDO::PARAM_INT);
     $stmt_check->execute();
     $existing_status = $stmt_check->fetch(PDO::FETCH_ASSOC);
@@ -114,7 +114,7 @@ try {
     } else {
         // Insert new status
         $stmt_insert = $pdo->prepare("INSERT INTO email_statuses (email_id, user_id, status, created_at, updated_at) VALUES (:email_id, :user_id, :status, :created_at, :updated_at)");
-        $stmt_insert->bindParam(':email_id', $post_id, PDO::PARAM_INT);
+        $stmt_insert->bindParam(':email_id', $email_id, PDO::PARAM_INT);
         $stmt_insert->bindParam(':user_id', $user_id, PDO::PARAM_INT);
         $stmt_insert->bindParam(':status', $status, PDO::PARAM_STR);
         $current_time = date('Y-m-d H:i:s');

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -323,6 +323,8 @@ img {
 }
 
 #feed-container {
+    max-width: 800px;
+    margin: 0 auto;
     /* No specific background needed if #main-content has it */
 }
 
@@ -536,6 +538,18 @@ img {
     background-color: #f8f9ff;
     border-left: 3px solid var(--link-color);
     padding-left: 13px;
+    position: relative;
+}
+
+.post-card.email-unread::before {
+    content: '';
+    position: absolute;
+    top: 15px;
+    left: 5px;
+    width: 8px;
+    height: 8px;
+    background-color: var(--link-color);
+    border-radius: 50%;
 }
 
 .post-card.email-unread .post-author-line .author-name,


### PR DESCRIPTION
- Add a max-width to the feed container to improve readability on large screens.
- Add a blue dot to unread emails to make them more noticeable.
- Fix mail status handling by renaming the `post_id` variable to `email_id` in `api/v1/set_post_status.php` to match what is being sent by the frontend.